### PR TITLE
Release v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alexjreyes",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alexjreyes",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "alexjreyes",
   "private": true,
   "description": "My portfolio",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": "Alex Reyes <me@alexjreyes.com>",
   "dependencies": {
     "ajv": "^8.17.1",


### PR DESCRIPTION
## Release v1.5.0

Version bump for portfolio and resume update.

### What's in this release

- 5 new projects: Koji, Zen Garden, A.L.A.N., Voice Clone, Serverless Web Crawler
- Removed 5 stale early-career projects
- New `Hardware` category and tags: `go`, `aws`, `iot`, `pytorch`, `docker`, `esphome`
- Full employment history in terminal resume (State Farm, Cyber Dive Co., FFUF Manila)
- Updated terminal skills and projects list
- Null-safe image handling in portfolio components

🤖 Generated with [Claude Code](https://claude.com/claude-code)